### PR TITLE
Systemd does not see all shutdowns as failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugfixes
 
 - [#2749](https://github.com/influxdata/telegraf/pull/2749): Fixed sqlserver input to work with case sensitive server collation.
+- [#2716](https://github.com/influxdata/telegraf/pull/2716): Systemd does not see all shutdowns as failures
 
 ## v1.3 [unreleased]
 

--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -9,6 +9,7 @@ User=telegraf
 ExecStart=/usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d ${TELEGRAF_OPTS}
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
+RestartForceExitStatus=SIGPIPE
 KillMode=control-group
 
 [Install]


### PR DESCRIPTION
````
[root@<hostname> ~]# systemctl status telegraf -l
● telegraf.service - The plugin-driven server agent for reporting metrics into InfluxDB
   Loaded: loaded (/usr/lib/systemd/system/telegraf.service; enabled; vendor preset: disabled)
   Active: inactive (dead) since Tue 2017-04-25 10:33:40 EDT; 14min ago
     Docs: https://github.com/influxdata/telegraf
 Main PID: 7857 (code=killed, signal=PIPE)
````

This occurs when we restart `systemd-journald`, which cause a crash/stop of telegraph seen as a STDPIPE

See https://github.com/hashicorp/consul/issues/1688 for more details and an example fix for prometheus. https://github.com/voxpupuli/puppet-prometheus/pull/3

### Required for all PRs:

- [ ] CHANGELOG.md updated (we recommend not updating this until the PR has been approved by a maintainer)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] README.md updated (if adding a new plugin)